### PR TITLE
Add Manga Maniacs Activity to Activities List

### DIFF
--- a/src/backend/database.py
+++ b/src/backend/database.py
@@ -163,6 +163,17 @@ initial_activities = {
         },
         "max_participants": 16,
         "participants": ["william@mergington.edu", "jacob@mergington.edu"]
+    },
+    "Manga Maniacs": {
+        "description": "Explore the fantastic stories of the most interesting characters from Japanese Manga (graphic novels).",
+        "schedule": "Tuesdays at 7pm",
+        "schedule_details": {
+            "days": ["Tuesday"],
+            "start_time": "19:00",
+            "end_time": "20:00"
+        },
+        "max_participants": 15,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
 Added new Manga Maniacs club to the website's activities list. This activity allows students to explore Japanese manga (graphic novels) stories and characters.
Implementation Details:
Added new activity with description, schedule, and capacity information
Schedule: Tuesdays at 7pm
Maximum attendance: 15 people
Category: Arts (automatically categorized based on content)